### PR TITLE
Add .jpeg extension and improve logging for direct media requests

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -38,7 +38,7 @@ const statusRequest = async (
 
   /* Check if domain is a direct media domain (i.e. d.fxtwitter.com),
      the tweet is prefixed with /dl/ or /dir/ (for TwitFix interop), or the
-     tweet ends in .mp4, .jpg, or .png
+     tweet ends in .mp4, .jpg, .jpeg, or .png
       
      Note that .png is not documented because images always redirect to a jpg,
      but it will help someone who does it mistakenly on something like Discord
@@ -46,7 +46,7 @@ const statusRequest = async (
      Also note that all we're doing here is setting the direct flag. If someone
      links a video and ends it with .jpg, it will still redirect to a .mp4! */
   if (
-    url.pathname.match(/\/status(es)?\/\d{2,20}\.(mp4|png|jpg)/g) !== null ||
+    url.pathname.match(/\/status(es)?\/\d{2,20}\.(mp4|png|jpe?g)/g) !== null ||
     Constants.DIRECT_MEDIA_DOMAINS.includes(url.hostname) ||
     prefix === 'dl' ||
     prefix === 'dir'

--- a/src/server.ts
+++ b/src/server.ts
@@ -45,13 +45,14 @@ const statusRequest = async (
       
      Also note that all we're doing here is setting the direct flag. If someone
      links a video and ends it with .jpg, it will still redirect to a .mp4! */
-  if (
-    url.pathname.match(/\/status(es)?\/\d{2,20}\.(mp4|png|jpe?g)/g) !== null ||
-    Constants.DIRECT_MEDIA_DOMAINS.includes(url.hostname) ||
-    prefix === 'dl' ||
-    prefix === 'dir'
-  ) {
+  if ( url.pathname.match(/\/status(es)?\/\d{2,20}\.(mp4|png|jpe?g)/g)) {
     console.log('Direct media request by extension');
+    flags.direct = true;
+  } else if (Constants.DIRECT_MEDIA_DOMAINS.includes(url.hostname)) {
+    console.log('Direct media request by domain');
+    flags.direct = true;
+  } else if (prefix === 'dl' || prefix === 'dir') {
+    console.log('Direct media request by path prefix');
     flags.direct = true;
   }
 


### PR DESCRIPTION
I've typed .jpg as .jpeg enough times now that I think supporting both extensions would help more than just me. I've also improved the logging for such requests by specifying what triggered it instead of leaving everything grouped under "extension".