### PR TITLE
Replace t.co URLs in user profile API responses.

### DIFF
--- a/src/api/status.ts
+++ b/src/api/status.ts
@@ -47,7 +47,7 @@ const populateTweetProperties = async (
   /* Populating a lot of the basics */
   apiTweet.url = `${Constants.TWITTER_ROOT}/${apiUser.screen_name}/status/${tweet.rest_id}`;
   apiTweet.id = tweet.rest_id;
-  apiTweet.text = unescapeText(linkFixer(tweet, tweet.legacy.full_text || ''));
+  apiTweet.text = unescapeText(linkFixer(tweet.legacy.entities?.urls, tweet.legacy.full_text || ''));
   apiTweet.author = {
     id: apiUser.id,
     name: apiUser.name,
@@ -93,7 +93,7 @@ const populateTweetProperties = async (
       tweet.note_tweet?.note_tweet_results?.result?.entity_set.symbols;
 
     console.log('We meet the conditions to use new note tweets');
-    apiTweet.text = unescapeText(linkFixer(tweet, noteTweetText));
+    apiTweet.text = unescapeText(linkFixer(tweet.legacy.entities.urls, noteTweetText));
     apiTweet.is_note_tweet = true;
   } else {
     apiTweet.is_note_tweet = false;
@@ -186,7 +186,7 @@ const populateTweetProperties = async (
     const translateAPI = await translateTweet(tweet, conversation.guestToken || '', language);
     if (translateAPI !== null && translateAPI?.translation) {
       apiTweet.translation = {
-        text: unescapeText(linkFixer(tweet, translateAPI?.translation || '')),
+        text: unescapeText(linkFixer(tweet.legacy?.entities?.urls, translateAPI?.translation || '')),
         source_lang: translateAPI?.sourceLanguage || '',
         target_lang: translateAPI?.destinationLanguage || '',
         source_lang_en: translateAPI?.localizedSourceLanguage || ''

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,5 +1,6 @@
 import { Constants } from '../constants';
 import { fetchUser } from '../fetch';
+import { linkFixer } from '../helpers/linkFixer';
 
 export const convertToApiUser = (user: GraphQLUser): APIUser => {
   const apiUser = {} as APIUser;
@@ -12,7 +13,7 @@ export const convertToApiUser = (user: GraphQLUser): APIUser => {
   apiUser.tweets = user.legacy.statuses_count;
   apiUser.name = user.legacy.name;
   apiUser.screen_name = user.legacy.screen_name;
-  apiUser.description = user.legacy.description;
+  apiUser.description = linkFixer(user.legacy.entities?.description?.urls, user.legacy.description);
   apiUser.location = user.legacy.location;
   apiUser.banner_url = user.legacy.profile_banner_url;
   /*

--- a/src/helpers/linkFixer.ts
+++ b/src/helpers/linkFixer.ts
@@ -1,10 +1,10 @@
 /* Helps replace t.co links with their originals */
-export const linkFixer = (tweet: GraphQLTweet, text: string): string => {
+export const linkFixer = (entities: TcoExpansion[] | undefined, text: string): string => {
   // console.log('got entities', {
   //   entities: tweet.legacy.entities
   // });
-  if (Array.isArray(tweet.legacy.entities?.urls) && tweet.legacy.entities.urls.length) {
-    tweet.legacy.entities.urls.forEach((url: TcoExpansion) => {
+  if (Array.isArray(entities) && entities.length) {
+    entities.forEach((url: TcoExpansion) => {
       let newURL = url.expanded_url;
 
       if (newURL.match(/^https:\/\/twitter\.com\/i\/web\/status\/\w+/g) !== null) {

--- a/src/types/twitterTypes.d.ts
+++ b/src/types/twitterTypes.d.ts
@@ -232,12 +232,7 @@ type GraphQLUser = {
     description: string; // "What's happening?!",
     entities: {
       description?: {
-        urls?: {
-          display_url: string; // "about.twitter.com",
-          expanded_url: string; // "https://about.twitter.com/",
-          url: string; // "https://t.co/DAtOo6uuHk",
-          indices: [0, 23];
-        }[];
+        urls?: TcoExpansion[];
       };
       url?: {
         urls?: {


### PR DESCRIPTION
When using the API to fetch a user profile, links in the user's description are not currently being replaced in the same way that links in tweets are.

This fixes that.

Example, Before:
```json
{
  "code": 200,
  "message": "OK",
  "user": {
    "url": "https://twitter.com/Distortion_2",
    "id": "723759170638491648",
    "followers": 33288,
    "following": 317,
    "likes": 581,
    "tweets": 471,
    "name": "Distortion2 🕐 Elden Ring DLC",
    "screen_name": "Distortion_2",
    "description": "https://t.co/LBHicdG5wf\nhttps://t.co/CDtsMJrd74        \nBusiness:\ndistortion2@ggtalentgroup.com\nPersonal:\nDist2twitch@gmail.com",
    "location": "Wisconsin, USA",
    "banner_url": "https://pbs.twimg.com/profile_banners/723759170638491648/1545479486",
    "avatar_url": "https://pbs.twimg.com/profile_images/1145084267455811584/w3zPQZfL_normal.jpg",
    "joined": "Sat Apr 23 06:23:27 +0000 2016",
    "website": null
  }
}
```
After:
```json
{
  "code": 200,
  "message": "OK",
  "user": {
    "url": "https://twitter.com/Distortion_2",
    "id": "723759170638491648",
    "followers": 33288,
    "following": 317,
    "likes": 581,
    "tweets": 471,
    "name": "Distortion2 🕐 Elden Ring DLC",
    "screen_name": "Distortion_2",
    "description": "http://twitch.tv/distortion2\nhttp://youtube.com/dist2gaming        \nBusiness:\ndistortion2@ggtalentgroup.com\nPersonal:\nDist2twitch@gmail.com",
    "location": "Wisconsin, USA",
    "banner_url": "https://pbs.twimg.com/profile_banners/723759170638491648/1545479486",
    "avatar_url": "https://pbs.twimg.com/profile_images/1145084267455811584/w3zPQZfL_normal.jpg",
    "joined": "Sat Apr 23 06:23:27 +0000 2016",
    "website": null
  }
}
```