### PR TITLE
Assign mosaic load balancing based on id

### DIFF
--- a/src/helpers/mosaic.ts
+++ b/src/helpers/mosaic.ts
@@ -1,16 +1,26 @@
 import { Constants } from '../constants';
 
+const getDomain = (twitterId: string): string | null => {
+  const mosaicDomains = Constants.MOSAIC_DOMAIN_LIST;
+
+  if (mosaicDomains.length === 0) {
+    return null;
+  }
+
+  let hash = 0;
+  for (let i = 0; i < twitterId.length; i++) {
+    const char = twitterId.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+  }
+  return mosaicDomains[Math.abs(hash) % mosaicDomains.length];
+}
+
 /* Handler for mosaic (multi-image combiner) */
 export const handleMosaic = async (
   mediaList: APIPhoto[],
   id: string
 ): Promise<APIMosaicPhoto | null> => {
-  const mosaicDomains = Constants.MOSAIC_DOMAIN_LIST;
-  let selectedDomain: string | null = null;
-  while (selectedDomain === null && mosaicDomains.length > 0) {
-    const domain = mosaicDomains[Math.floor(Math.random() * mosaicDomains.length)];
-    selectedDomain = domain;
-  }
+  const selectedDomain: string | null = getDomain(id);
 
   /* Fallback if there are no Mosaic servers */
   if (selectedDomain === null) {


### PR DESCRIPTION
Assign it to a server based off of the tweet id instead of just random to ensure consistency regardless of cache state