### PR TITLE
Add support for Revolt Chat's user-agent

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,7 +17,7 @@ export const Constants = {
   TWITTER_GLOBAL_NAME_ROOT: 'twitter.com',
   TWITTER_API_ROOT: 'https://api.twitter.com',
   BOT_UA_REGEX:
-    /bot|facebook|embed|got|firefox\/92|firefox\/38|curl|wget|go-http|yahoo|generator|whatsapp|preview|link|proxy|vkshare|images|analyzer|index|crawl|spider|python|cfnetwork|node|mastodon|http\.rb|ruby|bun\/|fiddler/gi,
+    /bot|facebook|embed|got|firefox\/92|firefox\/38|curl|wget|go-http|yahoo|generator|whatsapp|revoltchat|preview|link|proxy|vkshare|images|analyzer|index|crawl|spider|python|cfnetwork|node|mastodon|http\.rb|ruby|bun\/|fiddler/gi,
   /* 3 hours */
   GUEST_TOKEN_MAX_AGE: 3 * 60 * 60,
   GUEST_BEARER_TOKEN: `Bearer AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA`,


### PR DESCRIPTION
This pull request adds support for the revolt user-agent
``Mozilla/5.0 (compatible; January/1.0; +https://github.com/revoltchat/january)``